### PR TITLE
DYN-10209: Update pipeline.yml to migrate pipeline to CBCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DSPythonNet3
 
+[![Build Status](https://c007.cloudbees-ci.autodesk.com/buildStatus/icon?job=DYNCI%2FDynamo%2FPythonNet3Engine%2Fmaster)](https://c007.cloudbees-ci.autodesk.com/job/DYNCI/job/Dynamo/job/PythonNet3Engine/job/master/)
+
 This project builds the DSPythonNet3 dynamo python engine package.
 
 Building the project will output files in `package_output` that can be used to ship as a Dynamo package.

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -5,7 +5,7 @@ create_pr_release_to_public_master: true
 env:
   - GITHUB_ACCESS_TOKEN_ID: github_access_token_acsbuildguy
   - SLACK_QUANTUM_BUILD_CHANNEL : "#dynamo-jenkinsbuild"
-  - JENKINS_NODE_WIN: CDA-VS22-DT
+  - JENKINS_NODE_WIN: CDA-VS22-CBCI-DT
 
 jenkins_creds:
   -


### PR DESCRIPTION
## Summary
- Update `JENKINS_NODE_WIN` from `CDA-VS22-DT` to `CDA-VS22-CBCI-DT` in pipeline.yml
- Add CloudBees CI build status badge to README.md

## Details
- **Pipeline OS**: Windows
- **JENKINS_NODE_WIN**: CDA-VS22-DT → CDA-VS22-CBCI-DT
- **Branch**: dyn-10209
- README badge: Added (no previous badge existed)

[Dynamo CI CD on CBCI](https://autodesk.atlassian.net/wiki/x/PpPFGQ)